### PR TITLE
Include time of last activity in web interface.

### DIFF
--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -107,8 +107,11 @@ class MainPage implements WebPage {
 		statusContent.addChild("#", "Queued Event: " + spider.callbackExecutor.getQueue().size());
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Library buffer size: "+spider.getLibraryBufferSize());
+		long lastRequestFinishedAt = spider.getLastRequestFinishedAt();
 		long tStalled = spider.getStalledTime();
 		long tNotStalled = spider.getNotStalledTime();
+		statusContent.addChild("br");
+		statusContent.addChild("#", "Last Activity: " + ((lastRequestFinishedAt == 0) ? "never" : (TimeUtil.formatTime(System.currentTimeMillis() - lastRequestFinishedAt) + " ago")));
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Time stalled: "+TimeUtil.formatTime(tStalled));
 		statusContent.addChild("br");


### PR DESCRIPTION
Sometimes I wonder whether the spider is actually still running. This will show the last time a request finished or failed, giving a good indication of whether the plugin is still doing its thing or not. :)
