### PR TITLE
Search for usks - INCOMPATIBLE CHANGE REQUIRES MATCHING UPDATE IN plugin-Library

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,7 +4,7 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/fred"/>
-	<classpathentry kind="lib" path="/usr/share/java/junit.jar"/>
 	<classpathentry kind="lib" path="/fred/lib/freenet/freenet-ext.jar" sourcepath="/Contrib/db4o/src/db4oj"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="build"/>
 </classpath>

--- a/src/plugins/Spider/LibraryBuffer.java
+++ b/src/plugins/Spider/LibraryBuffer.java
@@ -97,7 +97,7 @@ public class LibraryBuffer implements FredPluginTalker {
 	public void start() {
 		// Do in a transaction so it gets committed separately.
 		spider.db.beginThreadTransaction(Storage.EXCLUSIVE_TRANSACTION);
-		spider.resetPages(Status.NOT_PUSHED, Status.QUEUED);
+		spider.resetPages(Status.NOT_PUSHED, Status.NEW);
 		spider.db.endThreadTransaction();
 	}
 

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -476,7 +476,9 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 	private class ClientGetterCallback implements ClientGetCallback {
 		@Override
 		public void onFailure(FetchException e, ClientGetter state) {
-			Logger.minor(this, "onFailure: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")");
+			Logger.minor(this,
+				     "onFailure: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")",
+				     e);
 			removeFuture(state);
 
 			if (stopped) return;
@@ -708,9 +710,16 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		}
 	}
 
+	/**
+	 * Do what needs to be done when a fetch request has failed.
+	 *
+	 * @param fe Is the exception that make it fail.
+	 *           Used to decide what to do.
+	 * @param getter is the ClientGetter that failed.
+	 */
 	protected void onFailure(FetchException fe, ClientGetter getter) {
-		FreenetURI uri = getter.getURI();
-		Logger.minor(this, "Failed: " + uri + " : " + getter, fe);
+		final FreenetURI uri = getter.getURI();
+		Logger.minor(this, "Failed: " + uri + " : " + getter);
 
 		synchronized (this) {
 			if (stopped) return;
@@ -748,7 +757,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 				page.setStatus(whereTo, "Redirected to " + newURI + " because of " + fe.getMode());
 				// redirect. This is done in an independent Runnable to get its own lock. 
 				final FreenetURI redirectedTo = newURI;
-				final FreenetURI redirectedFrom = getter.getURI();
+				final FreenetURI redirectedFrom = uri;
 				callbackExecutor.execute(new Runnable() {
 					@Override
 					public void run() {

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -64,6 +64,7 @@ import freenet.pluginmanager.FredPluginThreadless;
 import freenet.pluginmanager.FredPluginVersioned;
 import freenet.pluginmanager.PluginRespirator;
 import freenet.support.Logger;
+import freenet.support.Logger.LogLevel;
 import freenet.support.api.Bucket;
 import freenet.support.io.Closer;
 import freenet.support.io.NativeThread;
@@ -766,7 +767,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		private String title;
 		private int totalWords;
 
-		protected final boolean logDEBUG = Logger.shouldLog(Logger.DEBUG, this); // per instance, allow changing on the fly
+		protected final boolean logDEBUG = Logger.shouldLog(LogLevel.DEBUG, this); // per instance, allow changing on the fly
 
 		PageCallBack(Page page) {
 			this.page = page;
@@ -960,8 +961,6 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		return getRoot().getPageById(id);
 	}
 
-	// language for I10N
-	private LANGUAGE language;
 
     @Override
 	public String getString(String key) {
@@ -971,7 +970,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 
     @Override
 	public void setLanguage(LANGUAGE newLanguage) {
-		language = newLanguage;
+		Logger.debug(this, "New language set " + newLanguage + " - ignored.");
 	}
 
 	public PageMaker getPageMaker() {

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -778,6 +778,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			this.page = page;
 			try {
 				this.uri = new FreenetURI(page.getURI());
+				Logger.debug(this, "New PageCallBack for " + this.page + " (" + this.uri + ").");
 			} catch (MalformedURLException ex) {
 				Logger.error(this, "Error creating uri from '"+page.getURI()+"'", ex);
 			}
@@ -858,6 +859,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 				// Which is equal to log ( total count of files ) - log ( count of files with this word in )
 				librarybuffer.setRelevance(termPageEntry, ((float)termPageEntry.positionsSize()) / ((float)totalWords));
 			}
+			Logger.debug(this, "Finished PageCallBack for " + this.page + " (" + this.uri + ").");
 		}
 
 		HashMap<String, TermPageEntry> tpes = new HashMap<String, TermPageEntry>();

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -27,6 +27,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import plugins.Spider.index.TermPageEntry;
@@ -117,6 +118,10 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 	private LibraryBuffer librarybuffer;
 
 	private final AtomicLong lastRequestFinishedAt = new AtomicLong();
+	private final AtomicInteger subscribedToUSKs = new AtomicInteger();
+	private final AtomicInteger editionsFound = new AtomicInteger();
+
+	private Map<USK, Set<FreenetURI>> urisToReplace = Collections.synchronizedMap(new HashMap<USK, Set<FreenetURI>>());
 
 	public int getLibraryBufferSize() {
 		return librarybuffer.bufferUsageEstimate();
@@ -132,6 +137,18 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 
 	public long getLastRequestFinishedAt() {
 		return lastRequestFinishedAt.get();
+	}
+
+	public int getSubscribedUSKs() {
+		return subscribedToUSKs.get() - editionsFound.get();
+	}
+
+	public int getSubscribedToUSKs() {
+		return subscribedToUSKs.get();
+	}
+
+	public int getEditionsFound() {
+		return editionsFound.get();
 	}
 
 	public Config getConfig() {

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -393,11 +393,11 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 							bulkPageIterator.hasNext(maxParallelRequests)) {
 						Page page = bulkPageIterator.next();
 						Logger.debug(this, "Page " + page + " found in " + status + ".");
-						// Skip if getting this page already
-						if (runningFetch.containsKey(page.getURI())) continue;
-
 						try {
 							FreenetURI uri = new FreenetURI(page.getURI());
+							// Skip if getting this page already
+							if (runningFetch.containsKey(uri)) continue;
+
 							if (uri.isUSK()) {
 								uri = uri.setSuggestedEdition(page.getEdition());
 							}

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -503,8 +503,8 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		}
 	}
 
-	protected void onFailure(FetchException fe, ClientGetter state, Page page) {
-		Logger.minor(this, "Failed: " + page + " : " + state, fe);
+	protected void onFailure(FetchException fe, ClientGetter getter, Page page) {
+		Logger.minor(this, "Failed: " + page + " : " + getter, fe);
 
 		synchronized (this) {
 			if (stopped) return;
@@ -517,7 +517,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			synchronized (page) {
 				if (fe.newURI != null) {
 					// redirect, mark as succeeded
-					queueURI(fe.newURI, "redirect from " + state.getURI(), false);
+					queueURI(fe.newURI, "redirect from " + getter.getURI(), false);
 					page.setStatus(Status.SUCCEEDED);
 				} else if (fe.isFatal()) {
 					// too many tries or fatal, mark as failed

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -768,8 +768,24 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 				// too many tries or fatal, mark as failed
 				page.setStatus(Status.FATALLY_FAILED, "Fatal: " + fe.getMode());
 			} else {
-				// requeue at back
-				page.setStatus(Status.FAILED);
+				// If uris are already queued that are afterwards rendered "bad"
+				// by changing the badlisted extensions list, then they are cleaned
+				// out if they fail.
+				boolean badListed = false;
+				String sURI = uri.toString();
+				String lowerCaseURI = sURI.toLowerCase(Locale.US);
+				for (String ext : getRoot().getConfig().getBadlistedExtensions()) {
+					if (lowerCaseURI.endsWith(ext)) {
+						badListed = true;
+					}
+				}
+
+				if (badListed) {
+					page.setStatus(Status.FATALLY_FAILED);
+				} else {
+					// requeue at back
+					page.setStatus(Status.FAILED);
+				}
 			}
 			db.endThreadTransaction();
 			dbTransactionEnded = true;

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -119,6 +119,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 
 	private final AtomicLong lastRequestFinishedAt = new AtomicLong();
 	private final AtomicInteger subscribedToUSKs = new AtomicInteger();
+	private final AtomicInteger replacedByUSKs = new AtomicInteger();
 	private final AtomicInteger editionsFound = new AtomicInteger();
 
 	private Map<USK, Set<FreenetURI>> urisToReplace = Collections.synchronizedMap(new HashMap<USK, Set<FreenetURI>>());
@@ -139,12 +140,12 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		return lastRequestFinishedAt.get();
 	}
 
-	public int getSubscribedUSKs() {
-		return subscribedToUSKs.get() - editionsFound.get();
-	}
-
 	public int getSubscribedToUSKs() {
 		return subscribedToUSKs.get();
+	}
+
+	public int getReplacedByUSKs() {
+		return replacedByUSKs.get();
 	}
 
 	public int getEditionsFound() {
@@ -228,6 +229,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			return;
 		}
 		Set<FreenetURI> uris = urisToReplace.get(usk);
+		replacedByUSKs.getAndIncrement();
 		if (uris == null) {
 			subscribedToUSKs.getAndIncrement();
 			(clientContext.uskManager).subscribe(usk, this, false, this);

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -625,7 +625,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			 * provided).
 			 */
 			PageCallBack pageCallBack = new PageCallBack(page);
-			Logger.minor(this, "Successful: " + uri + " : " + page.getId());
+			Logger.minor(this, "Successful: " + uri + " id=" + page.getId());
 
 			try {
 				if ("text/plain".equals(mimeType)) {
@@ -653,7 +653,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 				db.endThreadTransaction();
 				dbTransactionEnded = true;
 
-				Logger.minor(this, "UnsafeContentTypeException " + uri + " : " + page.getId(), e);
+				Logger.minor(this, "" + e + " " + uri + " id=" + page.getId());
 				return; // Ignore
 			} catch (IOException e) {
 				// ugh?

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -905,6 +905,10 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 
 		PerstRoot root = (PerstRoot) db.getRoot();
 		if (root == null) PerstRoot.createRoot(db);
+		else {
+			// Not working:
+			// PerstRoot.patchRoot(db);
+		}
 
 		return db;
 	}

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -255,6 +255,10 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 				int maxParallelRequests = getRoot().getConfig().getMaxParallelRequests();
 				int running = runningFetch.size();
 
+				if (maxParallelRequests <= running) {
+					return;
+				}
+
 				// Prepare to start
 				toStart = new ArrayList<ClientGetter>(maxParallelRequests - running);
 				db.beginThreadTransaction(Storage.COOPERATIVE_TRANSACTION);

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -15,7 +15,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -247,7 +246,6 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 	 */
 	private void startFetches() {
 		ArrayList<ClientGetter> toStart = null;
-		List<FreenetURI> toSubscribe = new ArrayList<FreenetURI>();
 		synchronized (this) {
 			if (stopped) return;
 
@@ -850,7 +848,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			}
 		}
 
-		HashMap<String, TermPageEntry> tpes = new HashMap();
+		HashMap<String, TermPageEntry> tpes = new HashMap<String, TermPageEntry>();
 
 		/**
 		 * Add a word to the database for this page

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -188,6 +188,11 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			}
 		}
 
+		// Always add an USK page without the '-' to trigger search of versions.
+		if (uri.isUSK() && uri.getSuggestedEdition() < 0) {
+			uri = uri.setSuggestedEdition(-uri.getSuggestedEdition());
+		}
+
 		db.beginThreadTransaction(Storage.EXCLUSIVE_TRANSACTION);
 		boolean dbTransactionEnded = false;
 		try {
@@ -542,7 +547,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		boolean dbTransactionEnded = false;
 		db.beginThreadTransaction(Storage.EXCLUSIVE_TRANSACTION);
 		try {
-			librarybuffer.setBufferSize(getConfig().getNewFormatIndexBufferLimit()*1024*1024);
+			librarybuffer.setBufferSize(1 + getConfig().getNewFormatIndexBufferLimit()*1024*1024);
 			/*
 			 * instead of passing the current object, the pagecallback object for every page is
 			 * passed to the content filter this has many benefits to efficiency, and allows us to

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -242,6 +242,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 	 */
 	public void startSomeRequests() {
 		ArrayList<ClientGetter> toStart = null;
+		List<FreenetURI> toSubscribe = new ArrayList<FreenetURI>();
 		synchronized (this) {
 			if (stopped) return;
 
@@ -322,9 +323,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 					try {
 						uri = new FreenetURI(page.getURI());
 						if (uri.isSSKForUSK()) {
-							USK usk = USK.create(uri.uskForSSK());
-							if (urisToReplace.containsKey(usk)) continue;
-							subscribeUSK(usk.getURI(), uri);
+							toSubscribe.add(uri);
 							page.setStatus(Status.INDEXED);
 							started++;
 						}
@@ -345,6 +344,19 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			} catch (FetchException e) {
 				g.getClientCallback().onFailure(e, g);
 			}
+		}
+
+		for (FreenetURI uri : toSubscribe) {
+			USK usk;
+			try {
+				usk = USK.create(uri.uskForSSK());
+			} catch (MalformedURLException e1) {
+				continue;
+			}
+			if (urisToReplace.containsKey(usk)) {
+				continue;
+			}
+			subscribeUSK(usk.getURI(), uri);
 		}
 	}
 

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -237,6 +237,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 						} catch (MalformedURLException e) {
 							Logger.error(this, "IMPOSSIBLE-Malformed URI: " + page, e);
 							page.setStatus(Status.FAILED);
+							page.setComment("MalformedURLException");
 						}
 					}
 				} finally {
@@ -262,6 +263,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 						} catch (MalformedURLException e) {
 							Logger.error(this, "IMPOSSIBLE-Malformed URI: " + page, e);
 							page.setStatus(Status.FAILED);
+							page.setComment("MalformedURLException");
 						}
 					}
 				} finally {
@@ -484,6 +486,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			} catch (UnsafeContentTypeException e) {
 				// wrong mime type
 				page.setStatus(Status.SUCCEEDED);
+				page.setComment("UnsafeContentTypeException");
 				db.endThreadTransaction();
 				dbTransactionEnded = true;
 
@@ -523,7 +526,10 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 					db.beginThreadTransaction(Storage.EXCLUSIVE_TRANSACTION);
 					// page is now invalidated.
 					page = getRoot().getPageByURI(uri, false, "");
-					if(page != null) page.setStatus(Status.FAILED);
+					if(page != null) {
+						page.setStatus(Status.FAILED);
+						page.setComment("could not complete operation dbTransaction not ended");
+					}
 					db.endThreadTransaction();
 				}
 			}
@@ -546,9 +552,11 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 					// redirect, mark as succeeded
 					queueURI(fe.newURI, "redirect from " + getter.getURI(), false);
 					page.setStatus(Status.SUCCEEDED);
+					page.setComment("Redirected");
 				} else if (fe.isFatal()) {
 					// too many tries or fatal, mark as failed
 					page.setStatus(Status.FAILED);
+					page.setComment("Fatal");
 				} else {
 					// requeue at back
 					page.setStatus(Status.QUEUED);

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -269,7 +269,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 						try {
 							ClientGetter getter = makeGetter(page);
 
-							Logger.minor(this, "Starting " + getter + " " + page);
+							Logger.minor(this, "Starting new " + getter + " " + page);
 							toStart.add(getter);
 							runningFetch.put(page, getter);
 						} catch (MalformedURLException e) {
@@ -295,7 +295,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 						try {
 							ClientGetter getter = makeGetter(page);
 
-							Logger.minor(this, "Starting " + getter + " " + page);
+							Logger.minor(this, "Starting queued " + getter + " " + page);
 							toStart.add(getter);
 							runningFetch.put(page, getter);
 						} catch (MalformedURLException e) {

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -301,8 +301,8 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 	class BulkPageIterator implements Iterator<Page> {
 		private Status queue;
 		private Deque<Page> list = new LinkedList<Page>();
-		private int BULK_FETCH_SIZE = 1000;
-		private long TIME_TO_DEFER_DATABASE_READ = TimeUnit.SECONDS.toMillis(30);
+		private int BULK_FETCH_SIZE = 100;
+		private long TIME_TO_DEFER_DATABASE_READ = TimeUnit.SECONDS.toMillis(10);
 		private Date lastPoll = new Date();
 
 		BulkPageIterator(Status status) {

--- a/src/plugins/Spider/Spider.java
+++ b/src/plugins/Spider/Spider.java
@@ -415,13 +415,6 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 			}
 
 			for (final ClientGetter g : toStart) {
-				try {
-					g.start(clientContext);
-					Logger.minor(this, g + " started");
-				} catch (FetchException e) {
-					g.getClientCallback().onFailure(e, g);
-					continue;
-				}
 				ScheduledFuture<?> future = callbackExecutor.scheduleWithFixedDelay(new Runnable() {
 					long lapsLeft = 10 * 60 * 60; // Ten hours
 					@Override
@@ -435,6 +428,13 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 					}
 				}, 10, 1, TimeUnit.SECONDS);
 				runningFutures.put(g, future);
+				try {
+					g.start(clientContext);
+					Logger.minor(this, g + " started");
+				} catch (FetchException e) {
+					g.getClientCallback().onFailure(e, g);
+					continue;
+				}
 			}
 		}
 	}
@@ -481,7 +481,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 		@Override
 		public void onFailure(FetchException e, ClientGetter state) {
 			Logger.minor(this,
-				     "onFailure: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")",
+				     state + " onFailure: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")",
 				     e);
 			removeFuture(state);
 
@@ -492,7 +492,7 @@ public class Spider implements FredPlugin, FredPluginThreadless,
 
 		@Override
 		public void onSuccess(final FetchResult result, final ClientGetter state) {
-			Logger.minor(this, "onSuccess: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")");
+			Logger.minor(this, state + " onSuccess: " + state.getURI() + " (q:" + callbackExecutor.getQueue().size() + ")");
 			removeFuture(state);
 
 			if (stopped) return;

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -50,7 +50,7 @@ public class Page extends Persistent implements Comparable<Page> {
 	}
 
 	public synchronized void setComment(String comment) {
-		Logger.debug(this, "New comment for " + this);
+		Logger.debug(this, "New comment " + comment + " for " + this);
 		preModify();
 		this.comment = comment;
 		postModify();

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -114,9 +114,8 @@ public class Page extends Persistent implements Comparable<Page> {
 	
 	public void setPageTitle(String pageTitle) {
 		Logger.debug(this, "New page title for " + this);
-		preModify();
 		this.pageTitle = pageTitle;
-		postModify();
+		modify();
 	}
 
 	public String getPageTitle() {

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -32,7 +32,7 @@ public class Page extends Persistent implements Comparable<Page> {
 	Page(String uri, String comment, Storage storage) {
 		this.uri = uri;
 		this.comment = comment;
-		this.status = Status.QUEUED;
+		this.status = Status.NEW;
 		this.lastChange = System.currentTimeMillis();
 		
 		storage.makePersistent(this);

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -27,7 +27,12 @@ public class Page extends Persistent implements Comparable<Page> {
 	protected Status status;
 	/** Last Change Time */
 	protected long lastChange;
-	/** Last Fetched Time */
+	/** Last Fetched Time
+	 * 
+	 * This is for the case when many USK pages are updated more often 
+	 * than they are fetched. In that case, this is used to prioritize
+	 * the update of older pages over pages that were recently fetched.
+	 */
 	protected long lastFetched;
 	/** Comment, for debugging */
 	protected String comment;
@@ -41,7 +46,7 @@ public class Page extends Persistent implements Comparable<Page> {
 		this.comment = comment;
 		this.status = Status.NEW;
 		this.lastChange = System.currentTimeMillis();
-		this.lastFetched = 0L;
+		this.lastFetched = 0L; // 0 means never fetched.
 		
 		storage.makePersistent(this);
 	}
@@ -124,6 +129,25 @@ public class Page extends Persistent implements Comparable<Page> {
 
 	public Date getLastChange() {
 		return new Date(lastChange);
+	}
+
+	public void setLastFetched() {
+		lastFetched = System.currentTimeMillis();
+	}
+
+	public boolean hasBeenFetched() {
+		return lastFetched != 0L;
+	}
+
+	public Date getLastFetched() {
+		return new Date(lastFetched);
+	}
+
+	public String getLastFetchedAsString() {
+		if (lastFetched > 0L) {
+			return new Date(lastFetched).toString();
+		}
+		return "";
 	}
 
 	@Override

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -3,6 +3,8 @@
  */
 package plugins.Spider.db;
 
+import java.util.Date;
+
 import freenet.support.Logger;
 import plugins.Spider.org.garret.perst.FieldIndex;
 import plugins.Spider.org.garret.perst.IPersistentMap;
@@ -72,6 +74,10 @@ public class Page extends Persistent implements Comparable<Page> {
 
 	public String getPageTitle() {
 		return pageTitle;
+	}
+
+	public String getLastChange() {
+		return new Date(lastChange).toString();
 	}
 
 	@Override

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -128,8 +128,6 @@ public class Page extends Persistent implements Comparable<Page> {
 				if(e.getErrorCode() == StorageError.KEY_NOT_FOUND) {
 					// No serious consequences, so just log it, rather than killing the whole thing.
 					Logger.error(this, "Page: Key not found in index: "+this, e);
-					System.err.println("Page: Key not found in index: "+this);
-					e.printStackTrace();
 				} else {
 					Logger.error(this, "remove from index " + status + " failed", e);
 					throw e;

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -127,8 +127,10 @@ public class Page extends Persistent implements Comparable<Page> {
 					Logger.error(this, "Page: Key not found in index: "+this, e);
 					System.err.println("Page: Key not found in index: "+this);
 					e.printStackTrace();
-				} else
+				} else {
+					Logger.error(this, "remove from index " + status + " failed", e);
 					throw e;
+				}
 			} finally {
 				coll.unlock();
 			}

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -27,6 +27,8 @@ public class Page extends Persistent implements Comparable<Page> {
 	protected Status status;
 	/** Last Change Time */
 	protected long lastChange;
+	/** Last Fetched Time */
+	protected long lastFetched;
 	/** Comment, for debugging */
 	protected String comment;
 
@@ -39,6 +41,7 @@ public class Page extends Persistent implements Comparable<Page> {
 		this.comment = comment;
 		this.status = Status.NEW;
 		this.lastChange = System.currentTimeMillis();
+		this.lastFetched = 0L;
 		
 		storage.makePersistent(this);
 	}

--- a/src/plugins/Spider/db/Page.java
+++ b/src/plugins/Spider/db/Page.java
@@ -76,8 +76,12 @@ public class Page extends Persistent implements Comparable<Page> {
 		return pageTitle;
 	}
 
-	public String getLastChange() {
+	public String getLastChangeAsString() {
 		return new Date(lastChange).toString();
+	}
+
+	public Date getLastChange() {
+		return new Date(lastChange);
 	}
 
 	@Override

--- a/src/plugins/Spider/db/PerstRoot.java
+++ b/src/plugins/Spider/db/PerstRoot.java
@@ -41,6 +41,14 @@ public class PerstRoot extends Persistent {
 		config = new Config(storage);
 	}
 	
+	/**
+	 * Finds or creates pages in the database.
+	 * 
+	 * @param uri The URI of the page to find.
+	 * @param create if true then the page is created if it doesn't exist.
+	 * @param comment is only used when create is true.
+	 * @return the page.
+	 */
 	public Page getPageByURI(FreenetURI uri, boolean create, String comment) {
 		idPage.exclusiveLock();
 		uriPage.exclusiveLock();
@@ -63,6 +71,15 @@ public class PerstRoot extends Persistent {
 			uriPage.unlock();
 			idPage.unlock();
 		}
+	}
+
+	/**
+	 * Find a page in the database.
+	 * @param uri The page to find.
+	 * @return null if not found
+	 */
+	public Page getPageByURI(FreenetURI uri) {
+		return getPageByURI(uri, false, null);
 	}
 
 	public Page getPageById(long id) {

--- a/src/plugins/Spider/db/PerstRoot.java
+++ b/src/plugins/Spider/db/PerstRoot.java
@@ -9,6 +9,7 @@ import plugins.Spider.org.garret.perst.Key;
 import plugins.Spider.org.garret.perst.Persistent;
 import plugins.Spider.org.garret.perst.Storage;
 import freenet.keys.FreenetURI;
+import freenet.support.Logger;
 
 public class PerstRoot extends Persistent {
 
@@ -53,6 +54,7 @@ public class PerstRoot extends Persistent {
 			Page page = uriPage.get(new Key(uri.toString()));
 
 			if (create && page == null) {
+				Logger.debug(this, "New page created for " + uri.toString());
 				page = new Page(uri.toString(), comment, getStorage());
 
 				idPage.append(page);

--- a/src/plugins/Spider/db/PerstRoot.java
+++ b/src/plugins/Spider/db/PerstRoot.java
@@ -35,7 +35,11 @@ public class PerstRoot extends Persistent {
 		uriPage = storage.createFieldIndex(Page.class, "uri", true);
 		statusPages = new FieldIndex[Status.values().length];
 		for (Status status : Status.values()) {
-			statusPages[status.ordinal()] = storage.<Page>createFieldIndex(Page.class, "lastChange", true);
+			String fieldName = "lastChange";
+			if (status == Status.NEW_EDITION) {
+				fieldName = "lastFetched";
+			}
+			statusPages[status.ordinal()] = storage.<Page>createFieldIndex(Page.class, fieldName, true);
 		}
 
 		config = new Config(storage);

--- a/src/plugins/Spider/db/PerstRoot.java
+++ b/src/plugins/Spider/db/PerstRoot.java
@@ -141,4 +141,12 @@ public class PerstRoot extends Persistent {
 		return config;
 	}
 
+	public static void patchRoot(Storage storage) {
+		PerstRoot root = (PerstRoot) storage.getRoot();
+		root.newPages = storage.createFieldIndex(Page.class, "lastChange", false);
+
+		root.config = new Config(storage);
+		storage.setRoot(root);
+	}
+
 }

--- a/src/plugins/Spider/db/Status.java
+++ b/src/plugins/Spider/db/Status.java
@@ -11,7 +11,7 @@ public enum Status {
 	 * so they get re-run. */
 	QUEUED,
 	INDEXED, // The information is sent to library.
-	SUCCEEDED, // The fetch "succeeded" but we will ignore or not include the result.
+	SUCCEEDED, // The fetch "succeeded" but we will ignore or not include the result. Also when replaced with a new edition.
 	FAILED, // The fetch "failed" fatally and we will ignore the result.
 	NOT_PUSHED
 }

--- a/src/plugins/Spider/db/Status.java
+++ b/src/plugins/Spider/db/Status.java
@@ -4,9 +4,14 @@
 package plugins.Spider.db;
 
 public enum Status {
+	NEW, // Newly found URIs, i.e. queued but never fetched. This puts them priority-wise before QUEUED.
 	/** For simplicity, running is also mark as QUEUED. 
 	 * NOT_PUSHED, when LibraryBuffer is enabled, means we have successfully fetched the page but have not
 	 * yet uploaded the indexed data, so if we have an unclean shutdown we transfer all NOT_PUSHED to QUEUED
 	 * so they get re-run. */
-	QUEUED, INDEXED, SUCCEEDED, FAILED, NOT_PUSHED
+	QUEUED,
+	INDEXED, // The information is sent to library.
+	SUCCEEDED, // The fetch "succeeded" but we will ignore or not include the result.
+	FAILED, // The fetch "failed" fatally and we will ignore the result.
+	NOT_PUSHED
 }

--- a/src/plugins/Spider/db/Status.java
+++ b/src/plugins/Spider/db/Status.java
@@ -17,7 +17,7 @@ public enum Status {
 	 * so they get re-run. */
 	DONE, // The information is sent to library or there was no result. There is no more work to do.
 	PROCESSED_KSK, // The KSK has been sent to the library. We will rescan this later.
-	PROCESSED_USK, // The USK has been sent to the library. We will rescan this later.
+	PROCESSED_USK, // The USK has been sent to the library. Subscriptions are set up for these.
 	FAILED,
 	FATALLY_FAILED, // The fetch "failed" fatally and we will ignore the result and never try again.
 }

--- a/src/plugins/Spider/db/Status.java
+++ b/src/plugins/Spider/db/Status.java
@@ -10,6 +10,7 @@ package plugins.Spider.db;
  */
 public enum Status {
 	NEW, // Newly found URIs, i.e. never fetched.
+	NEW_EDITION, // Updated edition
 	NOT_PUSHED,
 	/**
 	 * NOT_PUSHED, when LibraryBuffer is enabled, means we have successfully fetched the page but have not

--- a/src/plugins/Spider/db/Status.java
+++ b/src/plugins/Spider/db/Status.java
@@ -3,15 +3,21 @@
  */
 package plugins.Spider.db;
 
+/**
+ * This enum also control the layout of the database so
+ * when changing this, be sure to update the dbVersion in
+ * Spider.
+ */
 public enum Status {
-	NEW, // Newly found URIs, i.e. queued but never fetched. This puts them priority-wise before QUEUED.
-	/** For simplicity, running is also mark as QUEUED. 
+	NEW, // Newly found URIs, i.e. never fetched.
+	NOT_PUSHED,
+	/**
 	 * NOT_PUSHED, when LibraryBuffer is enabled, means we have successfully fetched the page but have not
-	 * yet uploaded the indexed data, so if we have an unclean shutdown we transfer all NOT_PUSHED to QUEUED
+	 * yet uploaded the indexed data, so if we have an unclean shutdown we transfer all NOT_PUSHED to NEW
 	 * so they get re-run. */
-	QUEUED,
-	INDEXED, // The information is sent to library.
-	SUCCEEDED, // The fetch "succeeded" but we will ignore or not include the result. Also when replaced with a new edition.
-	FAILED, // The fetch "failed" fatally and we will ignore the result.
-	NOT_PUSHED
+	DONE, // The information is sent to library or there was no result. There is no more work to do.
+	PROCESSED_KSK, // The KSK has been sent to the library. We will rescan this later.
+	PROCESSED_USK, // The USK has been sent to the library. We will rescan this later.
+	FAILED,
+	FATALLY_FAILED, // The fetch "failed" fatally and we will ignore the result and never try again.
 }

--- a/src/plugins/Spider/index/TermEntry.java
+++ b/src/plugins/Spider/index/TermEntry.java
@@ -18,7 +18,8 @@ package plugins.Spider.index;
 */
 abstract public class TermEntry implements Comparable<TermEntry> {
 
-	final static long serialVersionUID = 0xF23194B7F015560CL;
+	// final static long serialVersionUID = 0xF23194B7F015560CL;
+	final static long serialVersionUID2 = 0xF33194B7F015560CL;
 
 	public enum EntryType {
 		INDEX, TERM, PAGE

--- a/src/plugins/Spider/index/TermEntryWriter.java
+++ b/src/plugins/Spider/index/TermEntryWriter.java
@@ -31,7 +31,7 @@ public class TermEntryWriter {
 	}
 	
 	public void writeObject(TermEntry en, DataOutputStream dos) throws IOException {
-		dos.writeLong(TermEntry.serialVersionUID);
+		dos.writeLong(TermEntry.serialVersionUID2);
 		TermEntry.EntryType type = en.entryType();
 		dos.writeInt(type.ordinal());
 		dos.writeUTF(en.subj);
@@ -39,14 +39,15 @@ public class TermEntryWriter {
 		switch (type) {
 		case PAGE:
 			TermPageEntry enn = (TermPageEntry)en;
-			enn.page.writeFullBinaryKeyWithLength(dos);
-			int size = enn.hasPositions() ? enn.positionsSize() : 0;
+			dos.writeUTF(enn.page.toString());
 			if(enn.title == null)
-				dos.writeInt(size);
+				dos.writeBoolean(false);
 			else {
-				dos.writeInt(~size); // invert bits to signify title is set
+				dos.writeBoolean(true);
 				dos.writeUTF(enn.title);
 			}
+			int size = enn.hasPositions() ? enn.positionsSize() : 0;
+			dos.writeInt(size);
 			if(size != 0) {
 				if(enn.hasFragments()) {
 					for(Map.Entry<Integer, String> p : enn.positionsMap().entrySet()) {
@@ -64,6 +65,8 @@ public class TermEntryWriter {
 				}
 			}
 			return;
+		default:
+			throw new RuntimeException("Not implemented");
 		}
 	}
 

--- a/src/plugins/Spider/index/TermPageEntry.java
+++ b/src/plugins/Spider/index/TermPageEntry.java
@@ -63,7 +63,9 @@ public class TermPageEntry extends TermEntry {
 		if (u == null) {
 			throw new IllegalArgumentException("can't have a null page");
 		}
-		page = u.intern(); // OPT LOW make the translator use the same URI object as from the URI table?
+		// intern forgets the suggested edition for USKs
+		// page = u.intern(); // OPT LOW make the translator use the same URI object as from the URI table?
+		page = u;
 		title = t == null ? null : t.intern();
 		if (p != null) {
 			posFragments = p;
@@ -79,7 +81,9 @@ public class TermPageEntry extends TermEntry {
 		if (u == null) {
 			throw new IllegalArgumentException("can't have a null page");
 		}
-		page = u.intern(); // OPT LOW make the translator use the same URI object as from the URI table?
+		// intern forgets the suggested edition for USKs
+		// page = u.intern(); // OPT LOW make the translator use the same URI object as from the URI table?
+		page = u;
 		title = null;
 		this.positions = pos;
 		this.posFragments = frags;

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -55,7 +55,7 @@ class MainPage implements WebPage {
 		if (addURI != null && addURI.length() != 0) {
 			try {
 				FreenetURI uri = new FreenetURI(addURI);
-				spider.queueURI(uri, "manually", true);
+				spider.queueURI(uri, "manually");
 
 				pageMaker.getInfobox("infobox infobox-success", "URI Added", contentNode).
 					addChild("#", "Added " + uri);

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -94,7 +94,7 @@ class MainPage implements WebPage {
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedToUSKs());
 		statusContent.addChild("br");
-		statusContent.addChild("#", "URIs replaced by the subscribed USKs: " + spider.getReplacedByUSKs());
+		statusContent.addChild("#", "URIs replaced by new USKs: " + spider.getNewUSKs());
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Found editions: " + spider.getEditionsFound());
 		statusContent.addChild("br");

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -109,10 +109,11 @@ class MainPage implements WebPage {
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Queued Event: " + spider.callbackExecutor.getQueue().size());
 		statusContent.addChild("br");
-		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedUSKs() +
-				" (subscribed: " + spider.getSubscribedToUSKs() +
-				" found " + spider.getEditionsFound() +
-				")");
+		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedToUSKs());
+		statusContent.addChild("br");
+		statusContent.addChild("#", "URIs replaced by the subscribed USKs: " + spider.getReplacedByUSKs());
+		statusContent.addChild("br");
+		statusContent.addChild("#", "Found editions: " + spider.getEditionsFound());
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Library buffer size: "+spider.getLibraryBufferSize());
 		long lastRequestFinishedAt = spider.getLastRequestFinishedAt();

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -5,7 +5,6 @@
 package plugins.Spider.web;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -78,13 +77,6 @@ class MainPage implements WebPage {
 		HTMLNode overviewTable = contentNode.addChild("table", "class", "column");
 		HTMLNode overviewTableRow = overviewTable.addChild("tr");
 
-		PageStatus newStatus = getPageStatus(Status.NEW);
-		PageStatus queuedStatus = getPageStatus(Status.QUEUED);
-		PageStatus indexedStatus = getPageStatus(Status.INDEXED);
-		PageStatus succeededStatus = getPageStatus(Status.SUCCEEDED);
-		PageStatus failedStatus = getPageStatus(Status.FAILED);
-		PageStatus notPushedStatus = getPageStatus(Status.NOT_PUSHED);
-
 		List<Page> runningFetch = spider.getRunningFetch();
 		Config config = spider.getConfig();
 
@@ -94,18 +86,10 @@ class MainPage implements WebPage {
 		statusContent.addChild("#", "Running Request: " + runningFetch.size() + "/"
 		        + config.getMaxParallelRequests());
 		statusContent.addChild("br");
-		statusContent.addChild("#", "New: " + newStatus.count);
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Queued: " + queuedStatus.count);
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Indexed: " + indexedStatus.count);
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Succeeded: " + succeededStatus.count);
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Not pushed: " + notPushedStatus.count);
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Failed: " + failedStatus.count);
-		statusContent.addChild("br");
+		for (Status status : Status.values()) {
+			statusContent.addChild("#", status + ": " + getPageStatus(status).count);
+			statusContent.addChild("br");
+		}
 		statusContent.addChild("#", "Queued Event: " + spider.callbackExecutor.getQueue().size());
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedToUSKs());
@@ -165,47 +149,14 @@ class MainPage implements WebPage {
 		}
 		contentNode.addChild(runningBox);
 
-		InfoboxNode newd = pageMaker.getInfobox("New URI");
-		HTMLNode newBox = newd.outer;
-		newBox.addAttribute("style", "right: 0; overflow: auto;");
-		HTMLNode newContent = newd.content;
-		listPages(newStatus, newContent);
-		contentNode.addChild(newBox);
-
-		InfoboxNode queued = pageMaker.getInfobox("Queued URI");
-		HTMLNode queuedBox = queued.outer;
-		queuedBox.addAttribute("style", "right: 0; overflow: auto;");
-		HTMLNode queuedContent = queued.content;
-		listPages(queuedStatus, queuedContent);
-		contentNode.addChild(queuedBox);
-
-		InfoboxNode indexed = pageMaker.getInfobox("Indexed URI");
-		HTMLNode indexedBox = indexed.outer;
-		indexedBox.addAttribute("style", "right: 0;");
-		HTMLNode indexedContent = indexed.content;
-		listPages(indexedStatus, indexedContent);
-		contentNode.addChild(indexedBox);
-
-		InfoboxNode succeeded = pageMaker.getInfobox("Succeeded URI");
-		HTMLNode succeededBox = succeeded.outer;
-		succeededBox.addAttribute("style", "right: 0;");
-		HTMLNode succeededContent = succeeded.content;
-		listPages(succeededStatus, succeededContent);
-		contentNode.addChild(succeededBox);
-
-		InfoboxNode notPushed = pageMaker.getInfobox("Not pushed URI");
-		HTMLNode notPushedBox = notPushed.outer;
-		notPushedBox.addAttribute("style", "right: 0;");
-		HTMLNode notPushedContent = notPushed.content;
-		listPages(notPushedStatus, notPushedContent);
-		contentNode.addChild(notPushedBox);
-
-		InfoboxNode failed = pageMaker.getInfobox("Failed URI");
-		HTMLNode failedBox = failed.outer;
-		failedBox.addAttribute("style", "right: 0;");
-		HTMLNode failedContent = failed.content;
-		listPages(failedStatus, failedContent);
-		contentNode.addChild(failedBox);
+		for (Status status : Status.values()) {
+			InfoboxNode d = pageMaker.getInfobox(status + " URIs");
+			HTMLNode box = d.outer;
+			box.addAttribute("style", "right: 0; overflow: auto;");
+			HTMLNode content = d.content;
+			listPages(getPageStatus(status), content);
+			contentNode.addChild(box);
+		}
 	}
 
 	//-- Utilities
@@ -216,7 +167,7 @@ class MainPage implements WebPage {
 			Iterator<Page> it = root.getPages(status);
 
 			int showURI = spider.getConfig().getMaxShownURIs();
-			List<Page> page = new ArrayList();
+			List<Page> page = new ArrayList<Page>();
 			while (page.size() < showURI && it.hasNext()) {
 				page.add(it.next());
 			}

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -109,6 +109,11 @@ class MainPage implements WebPage {
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Queued Event: " + spider.callbackExecutor.getQueue().size());
 		statusContent.addChild("br");
+		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedUSKs() +
+				" (subscribed: " + spider.getSubscribedToUSKs() +
+				" found " + spider.getEditionsFound() +
+				")");
+		statusContent.addChild("br");
 		statusContent.addChild("#", "Library buffer size: "+spider.getLibraryBufferSize());
 		long lastRequestFinishedAt = spider.getLastRequestFinishedAt();
 		long tStalled = spider.getStalledTime();
@@ -235,7 +240,7 @@ class MainPage implements WebPage {
 				}
 				litem.addChild("p",
 						" " +
-						page.getLastChange() + " " +
+						page.getLastChangeAsString() + " " +
 						title + " " +
 						"(" + page.getComment() + ")");
 			}

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -79,6 +79,7 @@ class MainPage implements WebPage {
 		HTMLNode overviewTable = contentNode.addChild("table", "class", "column");
 		HTMLNode overviewTableRow = overviewTable.addChild("tr");
 
+		PageStatus newStatus = getPageStatus(Status.NEW);
 		PageStatus queuedStatus = getPageStatus(Status.QUEUED);
 		PageStatus indexedStatus = getPageStatus(Status.INDEXED);
 		PageStatus succeededStatus = getPageStatus(Status.SUCCEEDED);
@@ -93,6 +94,8 @@ class MainPage implements WebPage {
 		HTMLNode statusContent = pageMaker.getInfobox("#", "Spider Status", nextTableCell);
 		statusContent.addChild("#", "Running Request: " + runningFetch.size() + "/"
 		        + config.getMaxParallelRequests());
+		statusContent.addChild("br");
+		statusContent.addChild("#", "New: " + newStatus.count);
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Queued: " + queuedStatus.count);
 		statusContent.addChild("br");
@@ -156,6 +159,13 @@ class MainPage implements WebPage {
 			}
 		}
 		contentNode.addChild(runningBox);
+
+		InfoboxNode newd = pageMaker.getInfobox("New URI");
+		HTMLNode newBox = newd.outer;
+		newBox.addAttribute("style", "right: 0; overflow: auto;");
+		HTMLNode newContent = newd.content;
+		listPages(newStatus, newContent);
+		contentNode.addChild(newBox);
 
 		InfoboxNode queued = pageMaker.getInfobox("Queued URI");
 		HTMLNode queuedBox = queued.outer;

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -65,7 +65,6 @@ class MainPage implements WebPage {
 					addChild("#", e.getMessage());
 				Logger.normal(this, "Manual added URI cause exception", e);
 			}
-			spider.startSomeRequests();
 		}
 	}
 

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -4,6 +4,11 @@
  */
 package plugins.Spider.web;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -128,6 +133,40 @@ class MainPage implements WebPage {
 		addForm.addChild("label", "for", "addURI", "Add URI:");
 		addForm.addChild("input", new String[] { "name", "style" }, new String[] { "addURI", "width: 20em;" });
 		addForm.addChild("input", new String[] { "type", "value" }, new String[] { "submit", "Add" });
+		mainContent.addChild("p");
+		final File file = new File(".", "library.info");
+		FileReader fr = null;
+		BufferedReader br = null;
+		try {
+			fr = new FileReader(file);
+			br = new BufferedReader(fr);
+			String line;
+			while ((line = br.readLine()) != null) {
+				mainContent.addChild("#", line);
+				mainContent.addChild("br");
+			}
+			br.close();
+		} catch (FileNotFoundException e) {
+			// There is no such file. That is fine.
+		} catch (IOException e) {
+			// We suddenly couldn't read this file. Strange problem.
+			throw new RuntimeException(e);
+		} finally {
+			if (br != null) {
+				try {
+					br.close();
+				} catch (IOException e) {
+					// Ignore.
+				}
+			}
+			if (fr != null) {
+				try {
+					fr.close();
+				} catch (IOException e) {
+					// Ignore.
+				}
+			} 
+		}
 
 		InfoboxNode running = pageMaker.getInfobox("Running URI");
 		HTMLNode runningBox = running.outer;

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -242,6 +242,10 @@ class MainPage implements WebPage {
 				if (title == null) {
 					title = "";
 				}
+				String changed = page.getLastFetchedAsString();
+				if (!changed.equals("")) {
+					title = "Last changed " + changed + " " + title;
+				}
 				long edition = page.getEdition();
 				if (edition != 0L) {
 					title = "Edition " + edition + " " + title;

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -219,6 +219,15 @@ class MainPage implements WebPage {
 			for (Page page : pageStatus.pages) {
 				HTMLNode litem = list.addChild("li", "title", page.getComment());
 				litem.addChild("a", "href", "/freenet:" + page.getURI(), page.getURI());
+				String title = page.getPageTitle();
+				if (title == null) {
+					title = "";
+				}
+				litem.addChild("p",
+						" " +
+						page.getLastChange() + " " +
+						title + " " +
+						"(" + page.getComment() + ")");
 			}
 		}
 	}

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -111,9 +111,7 @@ class MainPage implements WebPage {
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Subscribed USKs: " + spider.getSubscribedToUSKs());
 		statusContent.addChild("br");
-		statusContent.addChild("#", "URIs replaced by new USKs: " + spider.getNewUSKs());
-		statusContent.addChild("br");
-		statusContent.addChild("#", "Found editions: " + spider.getEditionsFound());
+		statusContent.addChild("#", "Found new editions: " + spider.getEditionsFound());
 		statusContent.addChild("br");
 		statusContent.addChild("#", "Library buffer size: "+spider.getLibraryBufferSize());
 		long lastRequestFinishedAt = spider.getLastRequestFinishedAt();

--- a/src/plugins/Spider/web/MainPage.java
+++ b/src/plugins/Spider/web/MainPage.java
@@ -90,15 +90,19 @@ class MainPage implements WebPage {
 		HTMLNode overviewTable = contentNode.addChild("table", "class", "column");
 		HTMLNode overviewTableRow = overviewTable.addChild("tr");
 
-		List<String> runningFetch = spider.getRunningFetch();
 		Config config = spider.getConfig();
 
 		// Column 1
 		HTMLNode nextTableCell = overviewTableRow.addChild("td", "class", "first");
 		HTMLNode statusContent = pageMaker.getInfobox("#", "Spider Status", nextTableCell);
-		statusContent.addChild("#", "Running Request: " + runningFetch.size() + "/"
-		        + config.getMaxParallelRequests());
-		statusContent.addChild("br");
+		for (int i = 0; i < Config.statusesToProcess.length; i++) {
+			Status status = Config.statusesToProcess[i];
+			List<String> runningFetch = spider.getRunningFetch(status);
+			statusContent.addChild("#", "Running Request for " + status + ": " + runningFetch.size() + "/"
+			        + config.getMaxParallelRequests(status));
+			statusContent.addChild("br");
+			
+		}
 		for (Status status : Status.values()) {
 			statusContent.addChild("#", status + ": " + getPageStatus(status).count);
 			statusContent.addChild("br");
@@ -176,26 +180,27 @@ class MainPage implements WebPage {
 			} 
 		}
 
-		InfoboxNode running = pageMaker.getInfobox("Running URI");
-		HTMLNode runningBox = running.outer;
-		runningBox.addAttribute("style", "right: 0;");
-		HTMLNode runningContent = running.content;
+		for (Status status : Config.statusesToProcess) {
+			List<String> runningFetch = spider.getRunningFetch(status);
+			if (!runningFetch.isEmpty()) {
+				InfoboxNode running = pageMaker.getInfobox("Running URIs for " + status);
+				HTMLNode runningBox = running.outer;
+				runningBox.addAttribute("style", "right: 0;");
+				HTMLNode runningContent = running.content;
 
-		if (runningFetch.isEmpty()) {
-			runningContent.addChild("#", "NO URI");
-		} else {
-			runningContent.addChild("#", "USKs shown without edition.");
-			HTMLNode list = runningContent.addChild("ol", "style", "overflow: auto; white-space: nowrap;");
+				runningContent.addChild("#", "USKs shown without edition.");
+				HTMLNode list = runningContent.addChild("ol", "style", "overflow: auto; white-space: nowrap;");
 
-			Iterator<String> pi = runningFetch.iterator();
-			int maxURI = config.getMaxShownURIs();
-			for (int i = 0; i < maxURI && pi.hasNext(); i++) {
-				String runningURI = pi.next();
-				HTMLNode litem = list.addChild("li");
-				litem.addChild("a", "href", "/freenet:" + runningURI, runningURI);
+				Iterator<String> pi = runningFetch.iterator();
+				int maxURI = config.getMaxShownURIs();
+				for (int i = 0; i < maxURI && pi.hasNext(); i++) {
+					String runningURI = pi.next();
+					HTMLNode litem = list.addChild("li");
+					litem.addChild("a", "href", "/freenet:" + runningURI, runningURI);
+				}
+				contentNode.addChild(runningBox);
 			}
 		}
-		contentNode.addChild(runningBox);
 
 		for (Status status : Status.values()) {
 			InfoboxNode d = pageMaker.getInfobox(status + " URIs");


### PR DESCRIPTION
Changes to search for and find USKs instead of SSKs and to handle USKs in the database.

The most important changes are:
- Change the database to store editions separate from the URI (USK have edition 0 in the database). This makes different editions of the same page appear as one in the database.
- Add a last fetched field in the database.
- Change the indexes to separate between NEW and NEW_EDITION. Also separate PROCESSED_KSKs, and PROCESSED_USKs from DONE. The NEW_EDITION index is ordered on last fetched instead of last handled.
- Control fetching from NEW, NEW_EDITION and FAILED queues separately.
- Change the packing format of TermEntry sent to Library to allow sending USKs. This requires a corresponding fix in the plugin-Library that receives these TermEntrys.
- Change all SSK links that could be USKs into USKs before entered into the database.
- Catch redirect of a fetch if it is a USK with new edition to just add it to the queue again. For NEW_EDITIONs this will mean in at the top, for NEW it will mean at the end.
- Subscribe to new USKs for the USKs found.
- Show and info file on the Spider GUI.